### PR TITLE
package.yaml: rename 'example' binary to 'pretty-terminal-example'

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ ghc-options:
   - -Wtabs
 
 executables:
-  example:
+  pretty-terminal-example:
     main:                Main.hs
     source-dirs:         examples
     ghc-options:


### PR DESCRIPTION
'example' is an ambiguous executable name. For example 'amqp-worker'
also installs 'example' binary causing collisions when installed
as a system package.

Let's rename the binary to be less ambiguous.